### PR TITLE
COU WL: Fix status for `bill_payment_failure` event.

### DIFF
--- a/content/payments/billpay/pre-built-screens/user-events.mdx
+++ b/content/payments/billpay/pre-built-screens/user-events.mdx
@@ -140,7 +140,7 @@ Here are some sample payloads for the listed events. Note that we may add additi
   {`{
   "txnId": "AXO101557980",
   "mobileNumber": "9481773053",
-  "status": "PAYMENT_FAILURE",
+  "status": "PAYMENT_FAILED",
   "billId": "dfeeaf14-e43a-4196-90d0-41089e979ad5",
   "billerId": "MAHI00000NATIC",
   "billerName": "Mahindra Rural Housing Finance Ltd",


### PR DESCRIPTION
We send `PAYMENT_FAILED` and not `PAYMENT_FAILURE`.