### PR TITLE
Updated python example code

### DIFF
--- a/content/payments/bbps/resources/jwt.mdx
+++ b/content/payments/bbps/resources/jwt.mdx
@@ -167,12 +167,12 @@ payload   = {
     "iat" : datetime.datetime.utcnow(),
     "jti" : str(uuid.uuid1())
 }
-// generate a token like this
+# generate a token like this
 token = jwt.encode(payload, secret, algorithm="HS256")
-// And to decode the token and verify the aud claim—
+# And to decode the token and verify the aud claim—
 try:
     # verified claim
-    jwt.decode(token, secret, audience=api_key)
+    jwt.decode(token, secret, audience=scheme_id)
     print("Verified token")
 except jwt.PyJWTError:
     # unverified claim


### PR DESCRIPTION
This change will enable users to copy and run the JWT python example code without any modification. 