### PR TITLE
fix: Data session status

### DIFF
--- a/content/data/account-aggregator/api-integration/notifications.mdx
+++ b/content/data/account-aggregator/api-integration/notifications.mdx
@@ -67,7 +67,7 @@ The FI notification payload contains two status
 
 **Data Session Status** – returns updated status of the data session; determines whether to initiate Fetch API Data API
 
-- `ACTIVE`- FI data session is active
+- `PENDING`- FI data session is active
 - `COMPLETED`- All requested FIP(s) have status as `READY`
 - `EXPIRED`- Data session had expired and no data fetch can happen for the dataSessionId
 - `FAILED`- Data Session request failed, retry creating a new session
@@ -82,7 +82,7 @@ The FI notification payload contains two status
 
 Fetch FI Data API should be called only when these conditions are satified:
 
-- Data Session status is `ACTIVE` or `COMPLETED` (all FIPs are ready)
+- Data Session status is `PENDING` or `COMPLETED` (all FIPs are ready)
 - FIStatus is `READY`.
 
 ###### FI Notification Payload
@@ -97,7 +97,7 @@ Setu will notify you whenever the FIP (Financial Information Provider) responds 
   "dataSessionId": "378ec65c-f558-49fc-89ea-e880c2cf88b3",
   "success": true,
   "data": {
-    "status": "ACTIVE",
+    "status": "PENDING",
     "format": "json", // json or xml
     "DataRange": {
       "from": "2018-12-06T11:39:57.153Z",


### PR DESCRIPTION
The data session status being sent to FIUs is 'PENDING' and not 'ACTIVE'

FYI @shrivatsas 