### PR TITLE
Changed data type of platformBillIds

### DIFF
--- a/content/payments/bbps/notifications.mdx
+++ b/content/payments/bbps/notifications.mdx
@@ -36,9 +36,7 @@ A `SETTLEMENT_SUCCESSFUL` notification is sent to the biller after successful se
                     "currencyCode" : "INR",
                     "value"        : 108400 // in paise
                 },
-                "platformBillIds"   : [ // list of strings
-                    string
-                ],
+                "platformBillIds"   : ["platformBillId1", "platformBillId2"], // list of strings  
                 "status"            : "SETTLEMENT_SUCCESSFUL",
                 "transactionId"     : "1074362738220"
             }

--- a/content/payments/bbps/notifications.mdx
+++ b/content/payments/bbps/notifications.mdx
@@ -36,8 +36,8 @@ A `SETTLEMENT_SUCCESSFUL` notification is sent to the biller after successful se
                     "currencyCode" : "INR",
                     "value"        : 108400 // in paise
                 },
-                "platformBillIds"   : [
-                    integer
+                "platformBillIds"   : [ // list of strings
+                    string
                 ],
                 "status"            : "SETTLEMENT_SUCCESSFUL",
                 "transactionId"     : "1074362738220"


### PR DESCRIPTION
When billers are integrating this API, they are expecting the `platformBillIds` to be a list of integers. But we are actually sending a list of strings.

