### PR TITLE
fix(AG-1478): updated Get Consent API response

### DIFF
--- a/content/data/account-aggregator/api-integration/consent-flow.mdx
+++ b/content/data/account-aggregator/api-integration/consent-flow.mdx
@@ -223,14 +223,17 @@ If the consent is approved, the status in the response will be `ACTIVE`. After t
               <h5>Response</h5>
               <CodeBlockWithCopy language="json">
                 {`{
+    "id": "e082b325-2692-47cd-88cf-875068df9051"
     "url": "https://fiu.setu.co/consents/v2/webview/e082b325-2692-47cd-88cf-875068df9051",
     "status": "PENDING",
     "context": [],
-    "vua": "999999999@onemoney",
-    "consentStart": "2023-04-04T07:10:41.165Z",
-    "consentExpiry": "2023-08-02T12:40:41.165Z",
+    "detail": {
+        "vua": "9999999999@onemoney",
+        "consentStart": "2023-04-04T07:10:41.165Z",
+        "consentExpiry": "2023-08-02T12:40:41.165Z"
+    },
+    "accountsLinked": [],
     "traceId": "26b8bc4c-5d33-43a1-a58f-be5d4d0acbd0"
-}
 }`}
               </CodeBlockWithCopy>
               <p>
@@ -239,6 +242,7 @@ If the consent is approved, the status in the response will be `ACTIVE`. After t
               </p>
               <CodeBlockWithCopy language="json">
                 {`{
+    "id": "73633c01-d14d-4dbb-8a82-d82e53df5920",
     "url": "https://fiu.setu.co/v2/consents/webview/73633c01-d14d-4dbb-8a82-d82e53df5920",
     "status": "PENDING",
     "detail": {
@@ -283,6 +287,7 @@ If the consent is approved, the status in the response will be `ACTIVE`. After t
         "lastUsed": null,
         "count": "0"
     },
+    "accountsLinked": [],
     "traceId": "74d3032a-597e-40e1-859b-67b035e8a0e0"
 }`}
               </CodeBlockWithCopy>

--- a/content/data/account-aggregator/api-integration/data-apis.mdx
+++ b/content/data/account-aggregator/api-integration/data-apis.mdx
@@ -568,7 +568,7 @@ Auto-Fetch data feature aims to absorb this complexity from the FIUs. With Auto-
                             <CodeBlockWithCopy language="json">
 {`POST /your-webhook-endpoint
 {
-    "type": "FI_DATA_FAILURE",
+    "type": "FI_DATA_FAILED",
     "timestamp": "2023-08-28T17:12:51.521Z",
     "consentId": "af43608a-ed6e-4c65-9745-0386ba5fd91b",
     "success": true,


### PR DESCRIPTION
Get Consent API response was not as per the latest code.
Renamed `FI_DATA_FAILURE` to `FI_DATA_FAILED`