### PR TITLE
reverted removal of token API, unnecessary redirection

### DIFF
--- a/api-references/data/account-aggregator.json
+++ b/api-references/data/account-aggregator.json
@@ -30,6 +30,54 @@
     }
   ],
   "paths": {
+    "/users/login": {
+      "servers": [
+        {
+          "url": "https://orgservice-prod.setu.co/v1"
+        }
+      ],
+      "post": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "client",
+            "required": true,
+            "description": "",
+            "schema": {
+              "type": "string",
+              "enum": ["bridge"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenAPIResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenAPIRequest"
+              }
+            }
+          }
+        },
+        "summary": "Get Token",
+        "operationId": "getToken"
+      }
+    },
     "/v2/fips": {
       "get": {
         "parameters": [
@@ -107,18 +155,9 @@
         "parameters": [
           {
             "in": "header",
-            "name": "x-client_id",
+            "name": "Authorization",
             "required": true,
-            "description": "Client ID for authentication",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "x-client-secret",
-            "required": true,
-            "description": "Client secret for authentication",
+            "description": "Authorization Bearer token",
             "schema": {
               "type": "string"
             }
@@ -719,6 +758,38 @@
   },
   "components": {
     "schemas": {
+      "TokenAPIResponse": {
+        "type": "object",
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "description": "Bearer token"
+          },
+          "refresh_token": {
+            "type": "string",
+            "description": "Bearer token"
+          }
+        },
+        "required": ["access_token"]
+      },
+      "TokenAPIRequest": {
+        "type": "object",
+        "properties": {
+          "clientID": {
+            "type": "string",
+            "description": "client_id obtained from bridge"
+          },
+          "grant_type": {
+            "type": "string",
+            "enum": ["client_credentials"]
+          },
+          "secret": {
+            "type": "string",
+            "description": "client secret obtained from bridge"
+          }
+        },
+        "required": ["clientID", "grant_type", "secret"]
+      },
       "DataRefreshSuccessResponse": {
         "type": "object",
         "properties": {

--- a/content/data/account-aggregator/api-integration/account-availability-apis.mdx
+++ b/content/data/account-aggregator/api-integration/account-availability-apis.mdx
@@ -13,7 +13,7 @@ The Account Availability Check API enables Financial Information Users (FIUs) to
 
 ### Authentication
 
-FIUs must use [Auth Mechanism](/data/account-aggregator/api-reference#/operation~getToken) to obtain an access token for authentication. Include the access token in the Authorization header of some requests.
+FIUs must use [Auth Mechanism](/data/account-aggregator/api-reference#/operation~getToken) to obtain an access token for authentication. Include the access token in the Authorization header of each request.
 
 <hr class="primary" />
 

--- a/content/data/account-aggregator/api-integration/consent-flow.mdx
+++ b/content/data/account-aggregator/api-integration/consent-flow.mdx
@@ -738,7 +738,7 @@ This API retrieves the last data fetch status for a given consent ID. It provide
         },
         {
           key: "4",
-          label: <Badge type="failure">FAIL - No Date Sessions Fetched yet</Badge>,
+          label: <Badge type="failure">FAIL - No Data Sessions Fetched yet</Badge>,
           content: (
             <>
               <h5>Response</h5>


### PR DESCRIPTION
Reverted the following changes - 
1. Removal of Token API - Added the Token API back, since old customers are still using these as their reference, including this a separate API and in Auth Header while creation of consent can help retain consistency.

Rectified the following Typo as well - 
`FAIL - No Date Sessions Fetched yet
`
to 
`FAIL - No Data Sessions Fetched yet
`

<img width="780" alt="image" src="https://github.com/user-attachments/assets/3fddc67e-152a-4ba2-8ad9-bfe20dfd424f">
