### PR TITLE
added details for mock FIP

### DIFF
--- a/content/data/account-aggregator/api-integration/consent-flow.mdx
+++ b/content/data/account-aggregator/api-integration/consent-flow.mdx
@@ -185,7 +185,8 @@ The following steps are handled by Setu’s screens—
 - Setu sends notification to you to confirm consent approval. At this point, consent `status` is APPROVED or REJECTED
 
 <Callout type="tip">
-  Use Setu FIP and get access to mock financial data on staging{" "}
+  Use Setu FIP or Setu FIP-2 to get access to mock financial data on staging. We have created these accounts to mock the FIP data schema based on the FIType chosen.
+  Also, please note that Setu FIP has a dynamic OTP sent to the phone number with which you have created a consent, but Setu FIP-2 has a static OTP '123456'{" "}
 </Callout>
 
 <hr class="primary" />

--- a/content/data/account-aggregator/api-integration/consent-flow.mdx
+++ b/content/data/account-aggregator/api-integration/consent-flow.mdx
@@ -186,7 +186,7 @@ The following steps are handled by Setu’s screens—
 
 <Callout type="tip">
   Use Setu FIP or Setu FIP-2 to get access to mock financial data on staging. We have created these accounts to mock the FIP data schema based on the FIType chosen.
-  Also, please note that Setu FIP has a dynamic OTP sent to the phone number with which you have created a consent, but Setu FIP-2 has a static OTP '123456'{" "}
+  <br />Also, please note that Setu FIP has a dynamic OTP sent to the phone number with which you have created a consent, but Setu FIP-2 has a static OTP '123456'{" "}
 </Callout>
 
 <hr class="primary" />


### PR DESCRIPTION
Users were not aware that one of our mock FIPs (setu-fip-2) sends a static OTP, so have this in docs for sharing the same info.

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/363b406d-65f5-448c-a4f7-23c46b474ad1">

