### PR TITLE
Docs/data sessions per consent api ref

### DIFF
--- a/api-references/data/account-aggregator.json
+++ b/api-references/data/account-aggregator.json
@@ -568,7 +568,7 @@
           }
         },
         "summary": "Get data sessions by consent ID",
-        "description": "Retrieve all data sessions associated with the specified consent ID. Each session includes its unique ID, status, and creation timestamp.",
+        "description": "Retrieve all non-expired data sessions associated with the specified consent ID. Each session includes its unique ID, status, and creation timestamp.",
         "tags": [
           "Consent V2 APIs"
         ]

--- a/api-references/data/account-aggregator.json
+++ b/api-references/data/account-aggregator.json
@@ -45,7 +45,9 @@
             "description": "",
             "schema": {
               "type": "string",
-              "enum": ["bridge"]
+              "enum": [
+                "bridge"
+              ]
             }
           }
         ],
@@ -520,6 +522,70 @@
         }
       ]
     },
+    "/v2/consents/{consent_id}/data-sessions": {
+      "get": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "description": "Bearer token for authorization.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-product-instance-id",
+            "required": true,
+            "description": "Product instance ID of the Financial Information User (FIU).",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSessionsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSessionsListErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get data sessions by consent ID",
+        "description": "Retrieve all data sessions associated with the specified consent ID. Each session includes its unique ID, status, and creation timestamp.",
+        "tags": [
+          "Consent V2 APIs"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "consent_id",
+          "required": true,
+          "description": "Unique ID of the consent whose data sessions are to be retrieved.",
+          "schema": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
+    },
     "/v2/sessions": {
       "post": {
         "parameters": [
@@ -770,7 +836,9 @@
             "description": "Bearer token"
           }
         },
-        "required": ["access_token"]
+        "required": [
+          "access_token"
+        ]
       },
       "TokenAPIRequest": {
         "type": "object",
@@ -781,14 +849,20 @@
           },
           "grant_type": {
             "type": "string",
-            "enum": ["client_credentials"]
+            "enum": [
+              "client_credentials"
+            ]
           },
           "secret": {
             "type": "string",
             "description": "client secret obtained from bridge"
           }
         },
-        "required": ["clientID", "grant_type", "secret"]
+        "required": [
+          "clientID",
+          "grant_type",
+          "secret"
+        ]
       },
       "DataRefreshSuccessResponse": {
         "type": "object",
@@ -998,6 +1072,73 @@
           "data",
           "linkRefNumber",
           "maskedAccNumber"
+        ]
+      },
+      "DataSessionsListResponse": {
+        "type": "object",
+        "properties": {
+          "consentId": {
+            "type": "string",
+            "description": "Unique identifier for the consent."
+          },
+          "dataSessions": {
+            "type": "array",
+            "description": "List of data sessions associated with the consent.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "sessionId": {
+                  "type": "string",
+                  "description": "Unique identifier for the data fetch session."
+                },
+                "status": {
+                  "type": "string",
+                  "description": "Current status of the session (e.g., 'PENDING', 'COMPLETED', 'FAILED')."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Timestamp when the session was created, in ISO 8601 format."
+                }
+              },
+              "required": [
+                "sessionId",
+                "status",
+                "created_at"
+              ]
+            }
+          },
+          "traceId": {
+            "type": "string",
+            "description": "Trace ID for tracking the request across logs and systems."
+          }
+        },
+        "required": [
+          "consentId",
+          "dataSessions",
+          "traceId"
+        ]
+      },
+      "DataSessionsListErrorResponse": {
+        "type": "object",
+        "properties": {
+          "traceId": {
+            "type": "string",
+            "description": "Trace ID for tracking the request."
+          },
+          "errorCode": {
+            "type": "string",
+            "description": "Error code indicating the type of failure."
+          },
+          "errorMsg": {
+            "type": "string",
+            "description": "Detailed message describing the error."
+          }
+        },
+        "required": [
+          "traceId",
+          "errorCode",
+          "errorMsg"
         ]
       },
       "FIFetchDecrpytedResponseFIItemDataItemData": {

--- a/content/data/account-aggregator/api-integration/consent-flow.mdx
+++ b/content/data/account-aggregator/api-integration/consent-flow.mdx
@@ -762,7 +762,7 @@ This API retrieves the last data fetch status for a given consent ID. It provide
 
 ### Get Data Sessions by Consent ID
 
-This API retrieves the list of data sessions associated with a given consent ID. It provides details such as the session ID, current status, and the creation timestamp. Sessions are sorted in descending order of creation time.
+This API retrieves the list of all non-expired data sessions associated with a given consent ID. It provides details such as the session ID, current status, and the creation timestamp. Sessions are sorted in descending order of creation time.
 
 ###### Request
 
@@ -836,22 +836,6 @@ This API retrieves the list of data sessions associated with a given consent ID.
         },
         {
           key: "2",
-          label: <Badge type="failure">FAIL - Wrong Product Instance ID</Badge>,
-          content: (
-            <>
-              <h5>Response</h5>
-              <CodeBlockWithCopy language="json">
-                {`{
-  "traceId": "09b6e082-448e-4c4d-9b48-0b1faaf5e9b5",
-  "errorCode": "NotFound",
-  "errorMsg": "Config not found for provided product instance. Please check the product instance id"
-}`}
-              </CodeBlockWithCopy>
-            </>
-          ),
-        },
-        {
-          key: "3",
           label: <Badge type="failure">FAIL - No Sessions Found</Badge>,
           content: (
             <>

--- a/content/data/account-aggregator/api-integration/consent-flow.mdx
+++ b/content/data/account-aggregator/api-integration/consent-flow.mdx
@@ -758,4 +758,117 @@ This API retrieves the last data fetch status for a given consent ID. It provide
   </Portion>
 </Row>
 
+<hr class="primary" />
+
+### Get Data Sessions by Consent ID
+
+This API retrieves the list of data sessions associated with a given consent ID. It provides details such as the session ID, current status, and the creation timestamp. Sessions are sorted in descending order of creation time.
+
+###### Request
+
+<table>
+  <tbody>
+    <tr>
+      <th>Base URL</th>
+      <td>
+        Sandbox: <code>https://fiu-sandbox.setu.co</code>
+        <br />
+        Production: <code>https://fiu.setu.co</code>
+      </td>
+    </tr>
+    <tr>
+      <th>Path</th>
+      <td>
+        <code>/v2/consents/:consent_id/data-sessions</code>
+      </td>
+    </tr>
+    <tr>
+      <th>Method</th>
+      <td>
+        <code>GET</code>
+      </td>
+    </tr>
+    <tr>
+      <th>Headers</th>
+      <td>
+        <code>Content-Type</code>: <code>application/json</code> <br />
+        <code>Authorization</code>: Bearer <code>access_token</code> <br />
+        <code>x-product-instance-id</code>: <code>product-instance-id</code> <br />
+        <code>Params</code>: <code>consent_request_id</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<br />
+
+<Callout type="tip">This is a GET API without any request body</Callout>
+
+<br />
+
+###### Sample Response
+
+<Row>
+  <Portion desktopSpan="whole">
+    <Tabs
+      tabs={[
+        {
+          key: "1",
+          label: <Badge type="success">SUCCESS</Badge>,
+          content: (
+            <>
+              <h5>Response</h5>
+              <CodeBlockWithCopy language="json">
+                {`{
+  "consentId": "e2304f07-6dae-4867-a0d7-8077cfbe2f87",
+  "dataSessions": [
+    {
+      "sessionId": "39faa19a-1f6a-4e10-85ad-2d5c6aa69257",
+      "status": "PENDING",
+      "created_at": "2024-12-17T12:14:26.537Z"
+    }
+  ],
+  "traceId": "064b8a84-accb-4303-9ddb-1447cb63b2b4"
+}`}
+              </CodeBlockWithCopy>
+            </>
+          ),
+        },
+        {
+          key: "2",
+          label: <Badge type="failure">FAIL - Wrong Product Instance ID</Badge>,
+          content: (
+            <>
+              <h5>Response</h5>
+              <CodeBlockWithCopy language="json">
+                {`{
+  "traceId": "09b6e082-448e-4c4d-9b48-0b1faaf5e9b5",
+  "errorCode": "NotFound",
+  "errorMsg": "Config not found for provided product instance. Please check the product instance id"
+}`}
+              </CodeBlockWithCopy>
+            </>
+          ),
+        },
+        {
+          key: "3",
+          label: <Badge type="failure">FAIL - No Sessions Found</Badge>,
+          content: (
+            <>
+              <h5>Response</h5>
+              <CodeBlockWithCopy language="json">
+                {`{
+  "consentId": "e2304f07-6dae-4867-a0d7-8077cfbe2f879",
+  "dataSessions": [],
+  "traceId": "e26bed44-ecab-4b7a-af09-02069d9a9ced"
+}`}
+              </CodeBlockWithCopy>
+            </>
+          ),
+        }
+      ]}
+    />
+  </Portion>
+</Row>
+
 <WasPageHelpful />


### PR DESCRIPTION
Added New API Get data sessions based on consent ID

Ref Tickets :  https://setu.atlassian.net/browse/AG-1697, https://setu.atlassian.net/browse/AG-1571

This is a new GET API that is added under _api-integration/consent-flow_ and _/api-reference_  under the Consent V2 APIs since it retrieve all non-expired data sessions associated with the specified consent ID. 

Added some lint suggestions as well.