### PR TITLE
Add UPMS biller fields and increase page limit

### DIFF
--- a/api-references/payments/billpay/api-integration.json
+++ b/api-references/payments/billpay/api-integration.json
@@ -3248,6 +3248,14 @@
               "type": "string",
               "format": "date-time"
             }
+          },
+          {
+            "name": "upmsEnabled",
+            "in": "query",
+            "description": "Filter billers by UPMS enabled status",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -3728,7 +3736,45 @@
                                 "type": "string",
                                 "example": "tags"
                               },
-                              "upms_registration_overriding_rule": {
+                              "upmsBillerParams": {
+                                "type": "array",
+                                "description": "UPMS-specific biller parameters",
+                                "items": {
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "description": "UPMS parameter name",
+                                      "example": "mandateType"
+                                    },
+                                    "value": {
+                                      "type": "string",
+                                      "description": "UPMS parameter value",
+                                      "example": "DEBIT",
+                                      "x-omitempty": true
+                                    }
+                                  }
+                                },
+                                "x-omitempty": true
+                              },
+                              "upmsBillerType": {
+                                "type": "string",
+                                "description": "Type of UPMS biller",
+                                "nullable": true,
+                                "example": "MULTIPLE",
+                                "x-omitempty": true
+                              },
+                              "upmsEnabled": {
+                                "type": "boolean",
+                                "description": "Indicates if UPMS is enabled for this biller",
+                                "nullable": true,
+                                "example": true,
+                                "x-omitempty": true
+                              },
+                              "upmsRegistrationOverridingRule": {
                                 "type": "string",
                                 "description": "Rule specifying how to handle UPMS registration conflicts",
                                 "nullable": true,
@@ -3918,7 +3964,7 @@
             "in": "query",
             "description": "Number of plans to return per page",
             "schema": {
-              "maximum": 1000.0,
+              "maximum": 4000.0,
               "minimum": 1.0,
               "type": "integer"
             }
@@ -5146,7 +5192,45 @@
                                             "type": "string",
                                             "example": "tags"
                                           },
-                                          "upms_registration_overriding_rule": {
+                                          "upmsBillerParams": {
+                                            "type": "array",
+                                            "description": "UPMS-specific biller parameters",
+                                            "items": {
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string",
+                                                  "description": "UPMS parameter name",
+                                                  "example": "mandateType"
+                                                },
+                                                "value": {
+                                                  "type": "string",
+                                                  "description": "UPMS parameter value",
+                                                  "example": "DEBIT",
+                                                  "x-omitempty": true
+                                                }
+                                              }
+                                            },
+                                            "x-omitempty": true
+                                          },
+                                          "upmsBillerType": {
+                                            "type": "string",
+                                            "description": "Type of UPMS biller",
+                                            "nullable": true,
+                                            "example": "MULTIPLE",
+                                            "x-omitempty": true
+                                          },
+                                          "upmsEnabled": {
+                                            "type": "boolean",
+                                            "description": "Indicates if UPMS is enabled for this biller",
+                                            "nullable": true,
+                                            "example": true,
+                                            "x-omitempty": true
+                                          },
+                                          "upmsRegistrationOverridingRule": {
                                             "type": "string",
                                             "description": "Rule specifying how to handle UPMS registration conflicts",
                                             "nullable": true,
@@ -5688,7 +5772,45 @@
                                                     "type": "string",
                                                     "example": "tags"
                                                   },
-                                                  "upms_registration_overriding_rule": {
+                                                  "upmsBillerParams": {
+                                                    "type": "array",
+                                                    "description": "UPMS-specific biller parameters",
+                                                    "items": {
+                                                      "required": [
+                                                        "name"
+                                                      ],
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string",
+                                                          "description": "UPMS parameter name",
+                                                          "example": "mandateType"
+                                                        },
+                                                        "value": {
+                                                          "type": "string",
+                                                          "description": "UPMS parameter value",
+                                                          "example": "DEBIT",
+                                                          "x-omitempty": true
+                                                        }
+                                                      }
+                                                    },
+                                                    "x-omitempty": true
+                                                  },
+                                                  "upmsBillerType": {
+                                                    "type": "string",
+                                                    "description": "Type of UPMS biller",
+                                                    "nullable": true,
+                                                    "example": "MULTIPLE",
+                                                    "x-omitempty": true
+                                                  },
+                                                  "upmsEnabled": {
+                                                    "type": "boolean",
+                                                    "description": "Indicates if UPMS is enabled for this biller",
+                                                    "nullable": true,
+                                                    "example": true,
+                                                    "x-omitempty": true
+                                                  },
+                                                  "upmsRegistrationOverridingRule": {
                                                     "type": "string",
                                                     "description": "Rule specifying how to handle UPMS registration conflicts",
                                                     "nullable": true,
@@ -6640,7 +6762,45 @@
                                                 "type": "string",
                                                 "example": "tags"
                                               },
-                                              "upms_registration_overriding_rule": {
+                                              "upmsBillerParams": {
+                                                "type": "array",
+                                                "description": "UPMS-specific biller parameters",
+                                                "items": {
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "UPMS parameter name",
+                                                      "example": "mandateType"
+                                                    },
+                                                    "value": {
+                                                      "type": "string",
+                                                      "description": "UPMS parameter value",
+                                                      "example": "DEBIT",
+                                                      "x-omitempty": true
+                                                    }
+                                                  }
+                                                },
+                                                "x-omitempty": true
+                                              },
+                                              "upmsBillerType": {
+                                                "type": "string",
+                                                "description": "Type of UPMS biller",
+                                                "nullable": true,
+                                                "example": "MULTIPLE",
+                                                "x-omitempty": true
+                                              },
+                                              "upmsEnabled": {
+                                                "type": "boolean",
+                                                "description": "Indicates if UPMS is enabled for this biller",
+                                                "nullable": true,
+                                                "example": true,
+                                                "x-omitempty": true
+                                              },
+                                              "upmsRegistrationOverridingRule": {
                                                 "type": "string",
                                                 "description": "Rule specifying how to handle UPMS registration conflicts",
                                                 "nullable": true,

--- a/content/payments/billpay/api-integration/upms.mdx
+++ b/content/payments/billpay/api-integration/upms.mdx
@@ -65,7 +65,11 @@ This document provides comprehensive information on:
 
 ### 2.1 UPMS Registration
 
-A UPMS registration represents an end-customer's mandate with a biller for automatic bill presentment via your app. A successful registration authorizes the biller (with customer consent) to push bill details for that customer through BBPS to us, and subsequently, to you via callbacks.
+A UPMS registration represents an end-customer's mandate with a UPMS enabled biller for automatic bill presentment via your app. A successful registration authorizes the biller (with customer consent) to push bill details for that customer through BBPS to us, and subsequently, to you via callbacks.
+
+<Callout type="warning">
+<b>UPMS is only available for billers who have the <code>upmsEnabled</code> flag set to <code>true</code>.</b> You can check this flag using the <a href="/payments/billpay/api-integration/api-reference#/category~List/operation~getBillers">List billers API</a>, which also allows filtering by this flag. Trying to create a UPMS registration for billers without <code>upmsEnabled</code> set to <code>true</code> will fail.
+</Callout>
 
 ### 2.2 Registration Lifecycle
 


### PR DESCRIPTION
- Add upmsEnabled query parameter for filtering billers
- Add upmsBillerParams, upmsBillerType, and upmsEnabled response fields
- Rename upms_registration_overriding_rule to upmsRegistrationOverridingRule
- Increase maximum page size from 1000 to 4000 for plans
- Add note on `upmsEnabled` flag for UPMS page