### PR TITLE
Update docs to use Bridge v2 report API and UI screens

### DIFF
--- a/content/payments/bbps/quickstart/api-integration.mdx
+++ b/content/payments/bbps/quickstart/api-integration.mdx
@@ -7,7 +7,7 @@ visible_in_sidebar: true
 
 ## API Integration
 
-Start by signing up on <a href="https://bridge.setu.co/" target="_blank">The Bridge ↗</a>, if you haven’t already. This is Setu’s single portal for managing all your integrations with us.
+Start by signing up on <a href="https://bridge.setu.co/v2/" target="_blank">The Bridge ↗</a>, if you haven’t already. This is Setu’s single portal for managing all your integrations with us.
 
 If you face any issues with integration, <a href="https://setu.co/support" target="_blank">raise a support ticket ↗</a> and our team will reach out.
 
@@ -17,18 +17,18 @@ If you face any issues with integration, <a href="https://setu.co/support" targe
 
 ##### Step 1 — Create a biller
 
-The primary entity on the BBPS network is called a “biller”. Go to the <a href="https://bridge.setu.co/products-list/payments" target="_blank">list of products</a> offered by Setu, and select one of the product cards under Payments > Collect BBPS.
+The primary entity on the BBPS network is called a “biller”. Go to the <a href="https://bridge.setu.co/v2" target="_blank">list of products</a> offered by Setu, and select one of the product cards under Payments > Collect BBPS.
 
-You will see multiple Collect BBPS cards, each by a different bank provider. While the underlying bank might differ, the product experience itself remains consistent across providers. Click on one of those cards, and you should see the full profile page with more details about the product. Click on the “Create a biller” button.
+Click on one of those cards, and you should see the full profile page with more details about the product. Click on the “Create a biller” button.
 
 <MainImage
-    src="https://storage.googleapis.com/strapi-assets/latest/biller_create_def9d37373/biller_create_def9d37373.gif"
+    src="https://storage.googleapis.com/strapi-assets/latest/biller_create_def9d37373/CreateBillerDemo4-ezgif.com-speed.gif"
     alt="Create a biller"
 />
 
 Here, enter the name of the biller. This is what your customers will see and search for in the payment apps, so make sure it has no errors.
 
-Below that, select the category this biller belongs to. Right now Setu supports only two categories, but should begin adding more soon. Now click on the “Create biller” button.
+Below that, select the category this biller belongs to. Now click on the “Create biller” button.
 
 And done! The biller has been created, and you can proceed to the biller dashboard.
 
@@ -52,10 +52,10 @@ And done! The biller has been created, and you can proceed to the biller dashboa
 
 <br />
 
-After the biller creation step, we should be on the biller profile. Here, you will see four tabs—**Dashboard**, which is an overview page, **Configuration** has all the integration details for this biller, **Transactions** where you can see test payments made to this biller, and **Copy to Production**, to copy the same config to Production later.
+After the biller creation step, we should be on the biller profile. Here, you will see four tabs—**Dashboard**, which is an overview page, **Add biller details** has all the integration details for this biller, **Test bill fetch and notification** where you can see test payments made to this biller, and **Setup details for production**, to copy the same config to Production later, **Add KYC details** where you need to provide essential business documents and verification details. This information is used to verify your business identity and ensure compliance with regulatory requirements.
 
 <MainImage
-    src="https://storage.googleapis.com/strapi-assets/latest/biller_dashboard_4da36b3b41/biller_dashboard_4da36b3b41.png"
+    src="https://storage.googleapis.com/strapi-assets/latest/biller_dashboard_4da36b3b41/CollectConfigPage.png"
     alt="Biller dashboard"
 />
 
@@ -79,7 +79,7 @@ Begin by defining _at least_ one identifier. An app like PhonePe or GPay will as
 <br />
 
 <MainImage
-    src="https://storage.googleapis.com/strapi-assets/latest/biller_config_8633de64a3/biller_config_8633de64a3.png"
+    src="https://storage.googleapis.com/strapi-assets/latest/biller_config_8633de64a3/CollectCustIdenPage.png"
     alt="Biller configuration"
 />
 
@@ -143,7 +143,7 @@ The `callbackURL` is for Setu to send notifications for `BILL_SETTLEMENT_STATUS`
 <br />
 
 <MainImage
-    src="https://storage.googleapis.com/strapi-assets/latest/biller_url_config_836bfdc83a/biller_url_config_836bfdc83a.png"
+    src="https://storage.googleapis.com/strapi-assets/latest/biller_url_config_836bfdc83a/CollectUrls.png"
     alt="Biller URL configuration"
 />
 
@@ -158,7 +158,7 @@ If you require notifications along with every settlement event, then setup the `
 Settlement accounts are where Setu will deposit money into after the customer has made the payment. Keep in mind that in Sandbox, these are mocked, and involve no money movement.
 
 <MainImage
-    src="https://storage.googleapis.com/strapi-assets/latest/biller_settlement_account_5bd1fc37f5/biller_settlement_account_5bd1fc37f5.png"
+    src="https://storage.googleapis.com/strapi-assets/latest/biller_settlement_account_5bd1fc37f5/CollectSettlePage.png"
     alt="Biller settlement account"
 />
 

--- a/content/payments/bbps/reports.mdx
+++ b/content/payments/bbps/reports.mdx
@@ -16,10 +16,10 @@ The request format is detailed below—
     <tr>
       <th>URL</th>
       <td>
-        Production: <code>https://bifrost.setu.co/bifrost/collect/reports</code>
+        Production: <code>https://bifrost.setu.co/bifrost/v2/collect/reports</code>
         <br />
         Sandbox:{" "}
-        <code>https://uat-bifrost.setu.co/bifrost/collect/reports</code>
+        <code>https://uat-bifrost.setu.co/bifrost/v2/collect/reports</code>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR updates our docs to reflect the usage of the Bridge V2 Report API, replacing all references to the older Bridge V1.
In addition, screenshots and UI flows shown in the docs have been updated to match the Bridge V2 interface