### PR TITLE
feat(AG-2053): Added whitelisting process for Onemoney consent testing in UAT

### DIFF
--- a/api-references/data/account-aggregator.json
+++ b/api-references/data/account-aggregator.json
@@ -3799,8 +3799,7 @@
               "102",
               "103",
               "104",
-              "105",
-              "106"
+              "105"
             ],
             "description": "Purpose Code as defined in the AA Technical Specification "
           },
@@ -4072,8 +4071,7 @@
               "102",
               "103",
               "104",
-              "105",
-              "106"
+              "105"
             ],
             "description": "Purpose Code as defined in the AA Technical Specification "
           },

--- a/api-references/data/account-aggregator_v1.json
+++ b/api-references/data/account-aggregator_v1.json
@@ -464,7 +464,7 @@
 					},
 					"code": {
 						"type": "string",
-						"enum": ["101", "102", "103", "104", "105", "106"],
+						"enum": ["101", "102", "103", "104", "105"],
 						"description": "Purpose Code as defined in the AA Technical Specification "
 					}
 				},

--- a/content/data/account-aggregator/api-integration/consent-flow.mdx
+++ b/content/data/account-aggregator/api-integration/consent-flow.mdx
@@ -195,6 +195,19 @@ The following steps are handled by Setu’s screens—
   Use Setu FIP or Setu FIP-2 to get access to mock financial data on staging. We have created these accounts to mock the FIP data schema based on the FIType chosen.
   <br />Also, please note that Setu FIP has a dynamic OTP sent to the phone number with which you have created a consent, but Setu FIP-2 has a static OTP '123456'{" "}
 </Callout>
+<br />
+
+<Callout type="warning">
+  <strong>Important Note for Onemoney AA Testing:</strong><br />
+  If you are using Onemoney as your AA partner in the UAT environment, please note that all new mobile numbers used for testing must be pre-whitelisted by the AA partner.<br /><br />
+  <strong>Key Points:</strong>
+  <ul>
+    <li>This applies only to new mobile numbers being used for UAT testing</li>
+    <li>Existing mobile numbers already in use for UAT testing do not require any action</li>
+    <li>The TAT for whitelisting is 1–2 business days from the time of request submission</li>
+  </ul>
+  Please factor this into your testing timelines and reach out to <strong>support@setu.co</strong> to whitelist any new mobile numbers in advance.
+</Callout>
 
 <hr class="primary" />
 

--- a/content/data/account-aggregator/consent-object.mdx
+++ b/content/data/account-aggregator/consent-object.mdx
@@ -67,7 +67,7 @@ The `context` parameter accepts key-value pairs to customize the consent flow. B
 | `excludeFipIds` | Exclude specific FIP IDs (comma-separated) | Any valid FIP ID |
 | `consentReviewAt` | Specify when consent should be reviewed | `first`, `last` |
 | `purposeDescription` | Add a custom description for the consent purpose | Any string |
-| `purposeCode` | Specify the purpose code | `101`, `102`, `103`, `104`, `105`, `106` |
+| `purposeCode` | Specify the purpose code | `101`, `102`, `103`, `104`, `105` |
 | `alternateNumber` | Enable/disable alternate number | `true`, `false` |
 | `accountSelectionMode` | Define how accounts should be selected | `single`, `multi`, `multi-opt-out` |
 | `transactionType` | Specify transaction type filter | `debit`, `credit` |


### PR DESCRIPTION
- Added whitelist process to test OM as AA partner in UAT
- Removed purposeCode 106 as that is not part of rebit spec

<img width="1299" alt="image" src="https://github.com/user-attachments/assets/6fb3da3f-956d-441b-9ddd-0a76fb9b532e" />
