### PR TITLE
remove imps and neft payment mode from bbps/api-integrations/object page

### DIFF
--- a/content/payments/billpay/api-integration/objects.mdx
+++ b/content/payments/billpay/api-integration/objects.mdx
@@ -34,8 +34,6 @@ Payment modes supported by a biller.
 | Credit Card      |
 | Debit Card       |
 | Prepaid Card     |
-| IMPS             |
-| NEFT             |
 | UPI              |
 | Wallet           |
 | AEPS             |
@@ -122,8 +120,6 @@ Details pertaining to the Agent which initiates the transaction. Values of the f
 | Credit Card      | Y   | Y    | Y   | Y    | Y   | Y        | Y     | Y   | Y   |
 | Debit Card       | Y   | Y    | Y   | Y    | Y   | Y        | Y     | Y   | Y   |
 | Prepaid Card     | Y   | Y    | Y   | Y    | Y   | Y        | Y     | Y   | Y   |
-| IMPS             | Y   | Y    | Y   | Y    | N   | Y        | N     | Y   | Y   |
-| NEFT             | Y   | Y    | Y   | Y    | Y   | Y        | N     | Y   | Y   |
 | UPI              | Y   | Y    | Y   | Y    | N   | Y        | N     | Y   | Y   |
 | Wallet           | Y   | Y    | Y   | Y    | N   | Y        | Y     | Y   | Y   |
 | AEPS             | N   | N    | Y   | N    | N   | Y        | N     | Y   | Y   |


### PR DESCRIPTION
This change removes IMPS and NEFT as payment modes from BBPS COU
Ticket : https://setu.atlassian.net/browse/COU-2064