### PR TITLE
docs(umap): fix typo 'payment.ending' → 'payment.pending' (#292)

### DIFF
--- a/content/payments/umap/payments.mdx
+++ b/content/payments/umap/payments.mdx
@@ -41,7 +41,7 @@ UPI Setu has consistent and transparent payment statuses across all transaction 
 | **Payment statuses** | **Description**                                  |
 | -------------------- | ------------------------------------------------ |
 | `payment.initiated`  | Payment has been attempted by a customer         |
-| `payment.ending`     | Payment is currently being processed by UPI Setu |
+| `payment.pending`     | Payment is currently being processed by UPI Setu |
 | `payment.success`    | Payment has been successfully completed          |
 | `payment.failed`     | Payment could not be processed                   |
 


### PR DESCRIPTION

Fixes a small typo in UPI/UMAP payments docs: payment.ending → payment.pending.
"payment.pending" is the correct state/phrase as reported in issue https://github.com/SetuHQ/docs/issues/292.

Scope
File: [content/payments/umap/payments.mdx](https://github.com/SetuHQ/docs/blob/main/content/payments/umap/payments.mdx)
No content restructuring or semantic changes.

Resolves https://github.com/SetuHQ/docs/issues/292.

before - 

<img width="1553" height="958" alt="Screenshot 2025-08-15 at 6 11 46 PM" src="https://github.com/user-attachments/assets/7930d5c7-ec15-4f47-befb-ca787077f663" />


after - 

<img width="1549" height="904" alt="Screenshot 2025-08-15 at 6 11 23 PM" src="https://github.com/user-attachments/assets/1fd153c0-070b-480c-af34-ec93de65dbc0" />
