### PR TITLE
Mandatory IP in MOB/MOBB

### DIFF
--- a/api-references/payments/billpay.json
+++ b/api-references/payments/billpay.json
@@ -146,7 +146,7 @@
                     "ip": {
                       "type": "string",
                       "example": "124.170.23.24",
-                      "description": "Mandatory if channel is `INT`, `INTB`. Not required for others."
+                      "description": "Mandatory if channel is `INT`, `INTB`, `MOB`, `MOBB`. Not required for others."
                     },
                     "imei": {
                       "type": "string",

--- a/api-references/payments/billpay/api-integration.json
+++ b/api-references/payments/billpay/api-integration.json
@@ -286,7 +286,7 @@
                           },
                           "ip": {
                             "type": "string",
-                            "description": "Mandatory if channel is `INT`, `INTB`. Not required for others.",
+                            "description": "Mandatory if channel is `INT`, `INTB`, `MOB`, `MOBB`. Not required for others.",
                             "format": "ipv4",
                             "example": "124.170.23.24"
                           },
@@ -3073,7 +3073,7 @@
                           },
                           "ip": {
                             "type": "string",
-                            "description": "Mandatory if channel is `INT`, `INTB`. Not required for others.",
+                            "description": "Mandatory if channel is `INT`, `INTB`, `MOB`, `MOBB`. Not required for others.",
                             "format": "ipv4",
                             "example": "124.170.23.24"
                           },

--- a/api-references/payments/billpay_v1/api-integration.json
+++ b/api-references/payments/billpay_v1/api-integration.json
@@ -237,7 +237,7 @@
                           },
                           "ip": {
                             "type": "string",
-                            "description": "Mandatory if channel is `INT`, `INTB`. Not required for others.",
+                            "description": "Mandatory if channel is `INT`, `INTB`, `MOB`, `MOBB`. Not required for others.",
                             "format": "ipv4",
                             "example": "124.170.23.24"
                           },
@@ -1222,7 +1222,7 @@
                           },
                           "ip": {
                             "type": "string",
-                            "description": "Mandatory if channel is `INT`, `INTB`. Not required for others.",
+                            "description": "Mandatory if channel is `INT`, `INTB`, `MOB`, `MOBB`. Not required for others.",
                             "format": "ipv4",
                             "example": "124.170.23.24"
                           },


### PR DESCRIPTION
## Summary

Add IP validation for Mobile (MOB) and Mobile Banking (MOBB) channels to align with NPCI specification requirements.

## Changes

- Updated `ValidateAgentParams` function in `internal/pkg/validators/agent.go` to require IP address for MOB and MOBB channels
- Previously, IP validation only applied to INT and INTB channels
- Now validates IP for all four channels: INT, INTB, MOB, MOBB as per NPCI device block parameter specification

## Impact

- **Breaking Change**: Requests with MOB/MOBB channels missing IP address will now be rejected
- Ensures compliance with NPCI specification (Section 21.1 - Initiating Channel Vs Device Block Parameters)
- Improves data quality and security posture for mobile channel transactions

## Testing

- Verify MOB channel requests without IP are rejected
- Verify MOBB channel requests without IP are rejected
- Verify existing other agent channel validations continue to work

## Reference

BBPS v14 API Spec: Section 21.1 - Device Block Tags for Mobile channels require: IP, IMEI, OS, APP

![image.png](/uploads/2997c5e637f0876fd7b1bf2b68c3aa23/image.png)