### PR TITLE
fix(seo): remove dead links and fix broken internal references

### DIFF
--- a/content/data/account-aggregator/overview.mdx
+++ b/content/data/account-aggregator/overview.mdx
@@ -36,8 +36,6 @@ The consent request carries details about the type of data, how long the FIU nee
 
 Already integrating? Checkout the AA Integration Guide [here](https://docs.setu.co/data/account-aggregator/quickstart).
 
-Try out our sample app built using Setu AA sandbox <a href="https://github.com/SetuHQ/account-aggregator-sample-app" target="_blank">here</a>
-
 <hr class="primary" />
 
 #### What can you build?

--- a/content/data/account-aggregator/quickstart.mdx
+++ b/content/data/account-aggregator/quickstart.mdx
@@ -16,8 +16,6 @@ Here is a quick summary of steps to help you integrate with Setu’s AA. Before 
 - **FI types / data sources**—The types of financial data you can request for, from your customers. Setu AA provides mock data for all 23 FI data types enabled by AA. You can check them out <a href="/data/account-aggregator/fi-data-types" target="_blank">here</a>.
 - **Consent Object**—This is core of the AA framework, wherein you (the FIU) request for consent from your customer to use one or more FI types. As part of the consent object, you would need to provide details like the reason for data request, how many times the data would be fetched etc. You can read more on the details that are sent as part of consent request <a href="/data/account-aggregator/consent-object" target="_blank">here</a>.
 
-Try out our sample app built using Setu AA sandbox <a href="https://github.com/SetuHQ/account-aggregator-sample-app" target="_blank">here</a>
-
 <hr class="primary" />
 
 ### Integrating FIU APIs on Sandbox

--- a/content/data/account-aggregator/v1/overview.mdx
+++ b/content/data/account-aggregator/v1/overview.mdx
@@ -32,8 +32,6 @@ The consent request carries details about the type of data, how long the FIU nee
 
 Already integrating? Checkout the AA Integration Guide [here](https://docs.setu.co/data/account-aggregator/quickstart).
 
-Try out our sample app built using Setu AA sandbox <a href="https://github.com/SetuHQ/account-aggregator-sample-app" target="_blank">here</a>
-
 <hr class="primary" />
 
 #### What can you build?

--- a/content/data/account-aggregator/v1/quickstart-v1.mdx
+++ b/content/data/account-aggregator/v1/quickstart-v1.mdx
@@ -16,14 +16,7 @@ Here is a quick summary of steps to help you integrate with Setu’s AA. Before 
 - **Consent object/request**—This is core of the AA framework, wherein you (the FIU) request for consent from your customer to use one or more FI types. As part of the consent object, you would need to provide details like the reason for data request, how many times the data would be fetched etc. You can read more on the details that are sent as part of consent request <a href="/data/account-aggregator/consent-object" target="_blank">here</a>.
 
 <Callout type="tip">
-  Use our{" "}
-  <a
-    href="https://github.com/SetuHQ/account-aggregator-sample-app"
-    target="_blank"
-  >
-    open source sample app
-  </a>{" "}
-  to follow along with the steps below.
+  Follow along with the steps below to get started.
 </Callout>
 
 <hr class="primary" />

--- a/content/data/account-aggregator/v1/quickstart.mdx
+++ b/content/data/account-aggregator/v1/quickstart.mdx
@@ -16,8 +16,6 @@ Here is a quick summary of steps to help you integrate with Setu’s AA. Before 
 - **FI types / data sources**—The types of financial data you can request for, from your customers. Setu AA provides mock data for all 23 FI data types enabled by AA. You can check them out <a href="/data/account-aggregator/fi-data-types" target="_blank">here</a>.
 - **Consent object/request**—This is core of the AA framework, wherein you (the FIU) request for consent from your customer to use one or more FI types. As part of the consent object, you would need to provide details like the reason for data request, how many times the data would be fetched etc. You can read more on the details that are sent as part of consent request <a href="/data/account-aggregator/consent-object" target="_blank">here</a>.
 
-Try out our sample app built using Setu AA sandbox <a href="https://github.com/SetuHQ/account-aggregator-sample-app" target="_blank">here</a>
-
 <hr class="primary" />
 
 ### Integrating FIU APIs on Sandbox

--- a/content/data/digilocker/overview.mdx
+++ b/content/data/digilocker/overview.mdx
@@ -13,7 +13,7 @@ DigiLocker is a document wallet from Government of India. Citizens can use it to
 
 Documents are fetched into DigiLocker directly from source of the issuer and are deemed to be at par with original physical documents as per Rule 9A of the Information Technology Rules, 2016. Documents can also be uploaded by citizens, for storage on DigiLocker.
 
-Read more about DigiLocker and the various documents supported <a href="https://www.digilocker.gov.in/dashboard" target="blank">here</a>.
+Read more about DigiLocker and the various documents supported <a href="https://www.digilocker.gov.in" target="_blank">here</a>.
 
 <hr class="primary" />
 

--- a/content/payments/bbps/go-live.mdx
+++ b/content/payments/bbps/go-live.mdx
@@ -95,7 +95,7 @@ Your customers can now pull their bills from your system via BBPS-supported apps
 
 You can access the transaction list from the Reports page from the link on the left nav bar, or the “Reports” tab inside the biller dashboard.
 
-Read more about <a href="/dev-tools/bridge/reports" target="_blank">reports &#8599;</a>.
+Read more about <a href="/dev-tools/bridge/analytics-and-reports" target="_blank">reports &#8599;</a>.
 
 <hr class="primary" />
 

--- a/content/payments/bbps/quickstart/no-code-integration.mdx
+++ b/content/payments/bbps/quickstart/no-code-integration.mdx
@@ -129,7 +129,7 @@ You can add new bills to the system in the same way as described above. When you
 <Callout type="highlight">
   When your customers make payments against bills, transaction and payment
   status is made available to you in the{" "}
-  <a href="/dev-tools/bridge/reports" target="_blank">
+  <a href="/dev-tools/bridge/analytics-and-reports" target="_blank">
     reports
   </a>{" "}
   section.

--- a/content/payments/billpay/api-integration/webhooks.mdx
+++ b/content/payments/billpay/api-integration/webhooks.mdx
@@ -700,7 +700,7 @@ URL    : To be provided by partner`}</CodeBlockWithCopy>
 
 ### Create UPMS Registration webhook
 
-This webhook informs you about the final status (Success, Failed, or Duplicate) of a UPMS registration request initiated via the [Fetch Bill and Create Registration API](/content/payments/billpay/api-integration/upms.mdx#31-creating-a-registration-combined-with-bill-fetch). The `refId` in the webhook payload matches the `upmsRegistration.refId` from the synchronous API response.
+This webhook informs you about the final status (Success, Failed, or Duplicate) of a UPMS registration request initiated via the [Fetch Bill and Create Registration API](/payments/billpay/api-integration/upms#31-creating-a-registration-combined-with-bill-fetch). The `refId` in the webhook payload matches the `upmsRegistration.refId` from the synchronous API response.
 
 <CodeBlockWithCopy language="json">{`Method : POST
 URL    : To be provided by partner (Registration Callback URL)`}</CodeBlockWithCopy>
@@ -817,7 +817,7 @@ URL    : To be provided by partner (Registration Callback URL)`}</CodeBlockWithC
 
 ### Update UPMS Registration webhook
 
-This webhook confirms the outcome (Success or Failed) of a request to update an existing customer registration using the [Update Registration API](/content/payments/billpay/api-integration/upms.mdx#33-updating-a-registration). The `refId` in the webhook payload matches the `upmsRegistrationRefID` used in the API request path.
+This webhook confirms the outcome (Success or Failed) of a request to update an existing customer registration using the [Update Registration API](/payments/billpay/api-integration/upms#33-updating-a-registration). The `refId` in the webhook payload matches the `upmsRegistrationRefID` used in the API request path.
 
 <CodeBlockWithCopy language="json">{`Method : POST
 URL    : To be provided by partner (Registration Callback URL)`}</CodeBlockWithCopy>
@@ -906,7 +906,7 @@ URL    : To be provided by partner (Registration Callback URL)`}</CodeBlockWithC
 
 ### Cancel UPMS Registration webhook
 
-This webhook confirms the outcome (Success or Failed) of a request to cancel an existing UPMS registration using the [Cancel Registration API](/content/payments/billpay/api-integration/upms.mdx#34-cancelling-a-registration). The `refId` in the webhook payload matches the `upmsRegistrationRefID` used in the API request path.
+This webhook confirms the outcome (Success or Failed) of a request to cancel an existing UPMS registration using the [Cancel Registration API](/payments/billpay/api-integration/upms#34-cancelling-a-registration). The `refId` in the webhook payload matches the `upmsRegistrationRefID` used in the API request path.
 
 <CodeBlockWithCopy language="json">{`Method : POST
 URL    : To be provided by partner (Registration Callback URL)`}</CodeBlockWithCopy>

--- a/content/payments/whatsapp-collect/journey.mdx
+++ b/content/payments/whatsapp-collect/journey.mdx
@@ -82,7 +82,7 @@ If you’re not registered as biller, contact Setu for more details on how to ge
 
 ##### Step 5 — Go live and start collections
 
-Go live and can start tracking your live transactions on The Bridge. Refer to <a href="/dev-tools/bridge/reports" target="_blank">this guide</a> on how to use reports.
+Go live and can start tracking your live transactions on The Bridge. Refer to <a href="/dev-tools/bridge/analytics-and-reports" target="_blank">this guide</a> on how to use reports.
 
 <NextPage
   info={{

--- a/content/payments/whatsapp-collect/reminders.mdx
+++ b/content/payments/whatsapp-collect/reminders.mdx
@@ -53,7 +53,7 @@ You need to share your customers’ bills with Setu, to send payment reminders t
 
 ##### Step 5 — Go live and start collections
 
-Go live and can start tracking your live transactions on The Bridge. Refer to <a href="/dev-tools/bridge/reports" target="_blank">this guide</a> on how to use reports.
+Go live and can start tracking your live transactions on The Bridge. Refer to <a href="/dev-tools/bridge/analytics-and-reports" target="_blank">this guide</a> on how to use reports.
 
 <hr class="primary" />
 


### PR DESCRIPTION
## Summary

Fixes broken links flagged in the SEO site audit. All replacement URLs verified as reachable.

- **Removed dead GitHub sample app links** from 5 Account Aggregator pages — `SetuHQ/account-aggregator-sample-app` repo no longer exists (confirmed deleted, not private)
- **Fixed DigiLocker URL** — `digilocker.gov.in/dashboard` was returning 404, updated to `digilocker.gov.in` (also fixed `target="blank"` → `target="_blank"`)
- **Fixed Bridge reports links** in 4 pages — `/dev-tools/bridge/reports` was 404, updated to `/dev-tools/bridge/analytics-and-reports`
- **Fixed malformed UPMS links** in `webhooks.mdx` — 3 links used raw file path (`/content/.../upms.mdx#section`) instead of URL path (`/payments/.../upms#section`)

## Files changed (11)

| Fix | Files |
|---|---|
| Remove sample app links | `data/account-aggregator/overview.mdx`, `quickstart.mdx`, `v1/overview.mdx`, `v1/quickstart.mdx`, `v1/quickstart-v1.mdx` |
| Fix DigiLocker URL | `data/digilocker/overview.mdx` |
| Fix Bridge reports links | `payments/bbps/go-live.mdx`, `payments/bbps/quickstart/no-code-integration.mdx`, `payments/whatsapp-collect/journey.mdx`, `payments/whatsapp-collect/reminders.mdx` |
| Fix UPMS links | `payments/billpay/api-integration/webhooks.mdx` |