### PR TITLE
fix(seo): update stale internal links to point to current page paths

### DIFF
--- a/content/data/digilocker/quickstart.mdx
+++ b/content/data/digilocker/quickstart.mdx
@@ -15,7 +15,7 @@ Here’s a quick run through of the APIs—
 - **Get DigiLocker request status**—Check status of a request that was created by passing the request `id`, at any point in the journey.
 - **Get list of all docs available**—Get a global list of all documents that DigiLocker lets you fetch and the identifiers required to fetch a particular document.
 - **Fetch a document**—Get the document that the user has consented to share with you, made available as a file URL to download. All docs other than Aadhaar, can be fetched with this API.
-- **Fetch Aadhaar data**—Fetch Aadhaar document data in JSON format as well as an XML file. The API response is consistent with our <a href="/data/okyc/overview" target="blank">OKYC APIs</a>, which aids in replacing OKYC with DigiLocker, for carrying out Aadhaar KYC.
+- **Fetch Aadhaar data**—Fetch Aadhaar document data in JSON format as well as an XML file. The API response is consistent with our <a href="/data" target="blank">OKYC APIs</a>, which aids in replacing OKYC with DigiLocker, for carrying out Aadhaar KYC.
 - **Revoke access token**—Revoke the OAuth user token, once necessary user documents are fetched.
 
 Additionally, here are the URLs you would need for these APIs—

--- a/content/dev-tools/bridge/v1/generate-token.mdx
+++ b/content/dev-tools/bridge/v1/generate-token.mdx
@@ -13,7 +13,7 @@ An API to generate tokens, which are used to authorise any other API requests ma
 
 ### Note on JWT authentication
 
-The generate token API works only with <a href="oauth">OAuth keys</a>. If you have implemented <a href="/dev-tools/bridge/org-settings/api-keys/jwt" target="_blank"> JWT auth </a> for Setu hosted endpoints, we recommend upgrading to OAuth soon. We support JWT auth but will not build any further features for it.
+The generate token API works only with <a href="oauth">OAuth keys</a>. If you have implemented <a href="/dev-tools/bridge/overview" target="_blank"> JWT auth </a> for Setu hosted endpoints, we recommend upgrading to OAuth soon. We support JWT auth but will not build any further features for it.
 
 **Please note**, that switching to OAuth will mean a change to all endpoints hosted by Setu. If the previous endpoint was `https://uat.setu.co/api/<path>`, it would change to `https://uat.setu.co/api/v2/<path>`—note the `/v2` added before the `<path>`.
 

--- a/content/dev-tools/bridge/v1/org-settings/api-keys/jwt-auth.mdx
+++ b/content/dev-tools/bridge/v1/org-settings/api-keys/jwt-auth.mdx
@@ -12,7 +12,7 @@ The JSON Web Token mechanism is used for securely communicating with Setu. It is
 The <a href="https://jwt.io/" target="_blank">JWT website ↗</a> covers the basics of how it works and the concepts involved. This guide provides a simple description of how JWT is implemented at Setu.
 &nbsp;
 
-**Please note**, while Setu supports JWT authentication, features like generating keys, using one key to access multiple configurations etc, will not be supported for JWT keys. Instead, use the more secure <a href="/dev-tools/bridge/org-settings/api-keys/oauth">OAuth API keys ↗</a> to access these features.
+**Please note**, while Setu supports JWT authentication, features like generating keys, using one key to access multiple configurations etc, will not be supported for JWT keys. Instead, use the more secure <a href="/dev-tools/bridge/overview">OAuth API keys ↗</a> to access these features.
 
 <hr class="primary" />
 
@@ -22,7 +22,7 @@ A partner needs to authenticate API requests made to Setu. One supported method 
 
 For Setu's products, JWT keys have a one-to-one mapping with individual product configurations. Essentially, each of your configurations come with their own JWT key that you can use to authorise API requests.
 
-If you are an Admin for your Bridge account, you should be able to see the API keys card under “Org settings” in the left panel. Click the JWT keys card to view keys for all your product configs. <a href="/dev-tools/bridge/org-settings/api-keys/jwt" target="_blank">Read more ↗</a>.
+If you are an Admin for your Bridge account, you should be able to see the API keys card under “Org settings” in the left panel. Click the JWT keys card to view keys for all your product configs. <a href="/dev-tools/bridge/overview" target="_blank">Read more ↗</a>.
 
 Read more below to understand the JWT format supported by Setu.
 

--- a/content/dev-tools/bridge/v1/org-settings/api-keys/jwt.mdx
+++ b/content/dev-tools/bridge/v1/org-settings/api-keys/jwt.mdx
@@ -9,7 +9,7 @@ visible_in_sidebar: true
 
 <Callout type="warning">
   We recommend using{" "}
-  <a href="/dev-tools/bridge/org-settings/api-keys/oauth" target="_blank">
+  <a href="/dev-tools/bridge/overview" target="_blank">
     OAuth keys
   </a>{" "}
   instead, which come with features like the ability to access multiple products

--- a/content/payments/bbps/resources/jwt.mdx
+++ b/content/payments/bbps/resources/jwt.mdx
@@ -121,7 +121,7 @@ For Setu products, JWT keys have a one-to-one mapping with individual product co
 
 <Callout type="warning">
   While we support JWT auth, we recommend using the more secure{" "}
-  <a href="/dev-tools/bridge/org-settings/api-keys/oauth" target="_blank">
+  <a href="/dev-tools/bridge/overview" target="_blank">
     OAuth keys
   </a>
   , which come with features like the ability to access multiple products with the
@@ -134,7 +134,7 @@ For Setu products, JWT keys have a one-to-one mapping with individual product co
 
 A merchant will call Setu APIs for creating payment links, checking link status, for fetching reports etc and can use JWT to authenticate such requests with Setu.
 
-If you are an Admin for your Bridge account, you should be able to see the API keys card under “Org settings” in the left panel. Click the JWT keys card to view keys for all your product configs. <a href="/dev-tools/bridge/org-settings/api-keys/jwt" target="_blank">Read more ↗</a>
+If you are an Admin for your Bridge account, you should be able to see the API keys card under “Org settings” in the left panel. Click the JWT keys card to view keys for all your product configs. <a href="/dev-tools/bridge/overview" target="_blank">Read more ↗</a>
 
 <hr class="primary" />
 

--- a/content/payments/bbps/resources/oauth.mdx
+++ b/content/payments/bbps/resources/oauth.mdx
@@ -146,7 +146,7 @@ On clicking “Generate new key”, you should see a simple form
 
 The “Generate key” button is enabled once all the fields are filled. Click it, and you should see the `clientID` and `secret` for this key.
 
-And done! You can now use this key to make API requests to Setu. <a href="/dev-tools/bridge/org-settings/api-keys/oauth" target="_blank">Read more ↗</a> on supported features for OAuth keys.
+And done! You can now use this key to make API requests to Setu. <a href="/dev-tools/bridge/overview" target="_blank">Read more ↗</a> on supported features for OAuth keys.
 
 <hr class="primary" />
 

--- a/content/payments/billpay/pre-built-screens/custom-payment.mdx
+++ b/content/payments/billpay/pre-built-screens/custom-payment.mdx
@@ -73,7 +73,7 @@ Depending on the platform you have chosen, please read the appropriate guide to 
 -   <a href="/payments/billpay/custom-payment/iOS" target="_blank">
         iOS
     </a>
--   <a href="/payments/billpay/custom-payment/cross-platform" target="_blank">
+-   <a href="/payments/billpay/pre-built-screens/custom-payment/cross-platform" target="_blank">
         Cross platform
     </a>
 

--- a/content/payments/billpay/pre-built-screens/custom-payment/iOS.mdx
+++ b/content/payments/billpay/pre-built-screens/custom-payment/iOS.mdx
@@ -10,7 +10,7 @@ visible_in_sidebar: true
 <Callout type="tip">
   This quickstart explains how to integrate when you opt for your own payment
   gateway. Use{" "}
-  <a href="/payments/billpay/quickstart/iOS" target="_blank">
+  <a href="/payments/billpay/pre-built-screens/quickstart/iOS" target="_blank">
     this guide
   </a>{" "}
   for Setu’s default UPI payment option.

--- a/content/payments/billpay/pre-built-screens/quickstart/android.mdx
+++ b/content/payments/billpay/pre-built-screens/quickstart/android.mdx
@@ -71,7 +71,7 @@ The above request will return URL based on the input params. Here’s a sample�
 
 The link returned by the API should be loaded within Android in an activity class with a webview component.
 
-If you’re using a cross platform solution—like Flutter, React Native, Ionic—look at the code snippets provided <a href="/payments/billpay/quickstart/cross-platform" target="_blank">here</a>.
+If you’re using a cross platform solution—like Flutter, React Native, Ionic—look at the code snippets provided <a href="/payments/billpay/pre-built-screens/quickstart/cross-platform" target="_blank">here</a>.
 
 <CodeBlockWithCopy language="java">
   {`public class DisplayWebView extends AppCompatActivity {

--- a/content/payments/billpay/v1/pre-built-screens/custom-payment.mdx
+++ b/content/payments/billpay/v1/pre-built-screens/custom-payment.mdx
@@ -73,7 +73,7 @@ Depending on the platform you have chosen, please read the appropriate guide to 
 -   <a href="/payments/billpay/custom-payment/iOS" target="_blank">
         iOS
     </a>
--   <a href="/payments/billpay/custom-payment/cross-platform" target="_blank">
+-   <a href="/payments/billpay/pre-built-screens/custom-payment/cross-platform" target="_blank">
         Cross platform
     </a>
 

--- a/content/payments/billpay/v1/pre-built-screens/custom-payment/iOS.mdx
+++ b/content/payments/billpay/v1/pre-built-screens/custom-payment/iOS.mdx
@@ -10,7 +10,7 @@ visible_in_sidebar: true
 <Callout type="tip">
   This quickstart explains how to integrate when you opt for your own payment
   gateway. Use{" "}
-  <a href="/payments/billpay/quickstart/iOS" target="_blank">
+  <a href="/payments/billpay/pre-built-screens/quickstart/iOS" target="_blank">
     this guide
   </a>{" "}
   for Setu’s default UPI payment option.

--- a/content/payments/billpay/v1/pre-built-screens/quickstart/android.mdx
+++ b/content/payments/billpay/v1/pre-built-screens/quickstart/android.mdx
@@ -71,7 +71,7 @@ The above request will return URL based on the input params. Here’s a sample�
 
 The link returned by the API should be loaded within Android in an activity class with a webview component.
 
-If you’re using a cross platform solution—like Flutter, React Native, Ionic—look at the code snippets provided <a href="/payments/billpay/quickstart/cross-platform" target="_blank">here</a>.
+If you’re using a cross platform solution—like Flutter, React Native, Ionic—look at the code snippets provided <a href="/payments/billpay/pre-built-screens/quickstart/cross-platform" target="_blank">here</a>.
 
 <CodeBlockWithCopy language="java">
   {`public class DisplayWebView extends AppCompatActivity {

--- a/content/payments/umap/refunds-disputes.mdx
+++ b/content/payments/umap/refunds-disputes.mdx
@@ -83,7 +83,7 @@ UPI Setu sends notifications to merchants for the following events
 
 - `dispute_created`
 
-Read more about dispute status notifications <a href="/payments/umap/notifications/disputes">here</a>
+Read more about dispute status notifications <a href="/payments/umap">here</a>
 
 ###### Step 2 - Respond to dispute as a merchant
 

--- a/content/payments/upi-deeplinks/resources/jwt.mdx
+++ b/content/payments/upi-deeplinks/resources/jwt.mdx
@@ -121,7 +121,7 @@ For Setu products, JWT keys have a one-to-one mapping with individual product co
 
 <Callout type="warning">
   While we support JWT auth, we recommend using the more secure{" "}
-  <a href="/dev-tools/bridge/org-settings/api-keys/oauth" target="_blank">
+  <a href="/dev-tools/bridge/overview" target="_blank">
     OAuth keys
   </a>
   , which come with features like the ability to access multiple products with the
@@ -134,7 +134,7 @@ For Setu products, JWT keys have a one-to-one mapping with individual product co
 
 A merchant will call Setu APIs for creating payment links, checking link status, for fetching reports etc and can use JWT to authenticate such requests with Setu.
 
-If you are an Admin for your Bridge account, you should be able to see the API keys card under “Org settings” in the left panel. Click the JWT keys card to view keys for all your product configs. <a href="/dev-tools/bridge/org-settings/api-keys/jwt" target="_blank">Read more ↗</a>
+If you are an Admin for your Bridge account, you should be able to see the API keys card under “Org settings” in the left panel. Click the JWT keys card to view keys for all your product configs. <a href="/dev-tools/bridge/overview" target="_blank">Read more ↗</a>
 
 <hr class="primary" />
 

--- a/content/payments/upi-deeplinks/resources/oauth.mdx
+++ b/content/payments/upi-deeplinks/resources/oauth.mdx
@@ -63,7 +63,7 @@ On clicking “Generate new key”, you should see a simple form
 
 The “Generate key” button is enabled once all the fields are filled. Click it, and you should see the `clientID` and `secret` for this key.
 
-And done! You can now use this key to make API requests to Setu. <a href="/dev-tools/bridge/org-settings/api-keys/oauth" target="_blank">Read more ↗</a> on supported features for OAuth keys.
+And done! You can now use this key to make API requests to Setu. <a href="/dev-tools/bridge/overview" target="_blank">Read more ↗</a> on supported features for OAuth keys.
 
 <hr class="primary" />
 


### PR DESCRIPTION
## Summary

Update 18 stale internal links across 14 MDX files to point directly to their current page paths, eliminating unnecessary redirect hops for users and crawlers.

## Changes

### Bridge org-settings links → `/dev-tools/bridge/overview` (10 instances)

Old `/dev-tools/bridge/org-settings/api-keys/jwt` and `/oauth` pages no longer exist. Updated across:
- `payments/bbps/resources/jwt.mdx` (2 links)
- `payments/bbps/resources/oauth.mdx` (1 link)
- `payments/upi-deeplinks/resources/jwt.mdx` (2 links)
- `payments/upi-deeplinks/resources/oauth.mdx` (1 link)
- `dev-tools/bridge/v1/generate-token.mdx` (1 link)
- `dev-tools/bridge/v1/org-settings/api-keys/jwt-auth.mdx` (2 links)
- `dev-tools/bridge/v1/org-settings/api-keys/jwt.mdx` (1 link)

### BillPay links → correct `pre-built-screens` paths (6 instances)

Content was moved under `pre-built-screens/` but links still used old paths. Updated both default and v1 versions:

| Old link | New link |
|---|---|
| `/payments/billpay/custom-payment/cross-platform` | `/payments/billpay/pre-built-screens/custom-payment/cross-platform` |
| `/payments/billpay/quickstart/iOS` | `/payments/billpay/pre-built-screens/quickstart/iOS` |
| `/payments/billpay/quickstart/cross-platform` | `/payments/billpay/pre-built-screens/quickstart/cross-platform` |

### Removed pages (2 instances)

| Old link | New link | File |
|---|---|---|
| `/payments/umap/notifications/disputes` | `/payments/umap` | `payments/umap/refunds-disputes.mdx` |
| `/data/okyc/overview` | `/data` | `data/digilocker/quickstart.mdx` |
