### PR TITLE
Add timeout failure case for payment status

### DIFF
--- a/content/payments/billpay/mobile-prepaid-recharge/webhooks.mdx
+++ b/content/payments/billpay/mobile-prepaid-recharge/webhooks.mdx
@@ -43,7 +43,7 @@ The system appends specific routes to your base `webhook_url` based on the event
 **Request Body**:
 
 <CodeBlockWithCopy language="json">{`{
-  "transactionRefId": "string",
+  "transactionRefId": "string (may be empty for timeout failures)",
   "trace_id": "string",
   "operatorRefId": "string",
   "status": "Successful | Failure",
@@ -58,7 +58,7 @@ The system appends specific routes to your base `webhook_url` based on the event
 
 | Field | Type | Description | Mandatory? |
 |-------|------|-------------|------------|
-| `transactionRefId` | string | Transaction reference ID from the original recharge request | Yes |
+| `transactionRefId` | string | Transaction reference ID from the original recharge request | Yes (may be empty) |
 | `trace_id` | string | System reference number (internal trace ID) | Yes |
 | `operatorRefId` | string | Operator transaction ID (if available) | No |
 | `status` | string | Transaction status - one of: `"Successful"`, `"Failure"` | Yes |
@@ -106,6 +106,28 @@ The system appends specific routes to your base `webhook_url` based on the event
   "mobile_number": "9876543210",
   "provider": "Airtel",
   "failureReason": "Insufficient balance",
+  "timestamp": "2026-01-09T11:56:26+05:30"
+}`}
+        </CodeBlockWithCopy>
+    </details>
+</Card>
+
+<Card padding="nano" shape="rounded">
+    <details>
+        <summary>
+            <Text weight="600" marginBottom="none">
+                Payment status webhook example (Timeout failure)
+            </Text>
+        </summary>
+        <CodeBlockWithCopy language="json">
+            {`{
+  "transactionRefId": "",
+  "trace_id": "SYS-ABC-125",
+  "status": "Failure",
+  "amount": "99.00",
+  "mobile_number": "9876543210",
+  "provider": "Airtel",
+  "failureReason": "Transaction timed out",
   "timestamp": "2026-01-09T11:56:26+05:30"
 }`}
         </CodeBlockWithCopy>


### PR DESCRIPTION
For `{webhook_url}/payment/status`, we've documented `transactionRefId` as mandatory. However, in timeout scenarios, `JRIStatusPollingWorkflow` marks the transaction as failed, and we end up sending the webhook with an empty `transactionRefId`.

Updating the documentation to indicate the same that `transactionRefId` can be sent as empty string as well in timeout cases.

<img width="773" height="687" alt="Screenshot 2026-06-23 at 12 29 19 PM" src="https://github.com/user-attachments/assets/eeebc674-3c25-4909-a5c4-4124ffe7f674" />

<img width="787" height="597" alt="Screenshot 2026-06-23 at 12 29 45 PM" src="https://github.com/user-attachments/assets/a1f48279-1f3a-43bd-861f-13a48d216d04" />
