### PR TITLE
[codex] Update Bridge docs links to v2

### DIFF
--- a/content/data/account-aggregator/v1/quickstart.mdx
+++ b/content/data/account-aggregator/v1/quickstart.mdx
@@ -24,7 +24,7 @@ Try out our sample app built using Setu AA sandbox <a href="https://github.com/S
 
 ##### Create an FIU config on the Bridge
 
-Register on <a href="https://bridge.setu.co/" target="_blank">The Bridge</a>, if you haven’t already. From the **Products** page, navigate to the **Data** tab. Select the Financial Information User to begin creating the FIU.
+Register on <a href="https://bridge.setu.co/v2/" target="_blank">The Bridge</a>, if you haven’t already. From the **Products** page, navigate to the **Data** tab. Select the Financial Information User to begin creating the FIU.
 
 You can read a bit about the FIU product on the profile page before clicking on the **Create an FIU** button.
 

--- a/content/dev-tools/bridge/v1/overview.mdx
+++ b/content/dev-tools/bridge/v1/overview.mdx
@@ -10,7 +10,7 @@ visible_in_sidebar: true
 The Bridge is a single web portal that lets you pick, configure and go live with your Setu integrations, generate and download transaction and settlement reports, invite users from your organisation to use our platform—with more features on the way.
 
 <p>
-  <a href="https://bridge.setu.co/signup" target="_blank">
+  <a href="https://bridge.setu.co/v2/signup" target="_blank">
     Sign up on The Bridge
   </a>{" "}
   to get started if you haven’t already.

--- a/content/payments/bbps/quickstart/api-integration.mdx
+++ b/content/payments/bbps/quickstart/api-integration.mdx
@@ -7,7 +7,7 @@ visible_in_sidebar: true
 
 ## API Integration
 
-Start by signing up on <a href="https://bridge.setu.co/" target="_blank">The Bridge ↗</a>, if you haven’t already. This is Setu’s single portal for managing all your integrations with us.
+Start by signing up on <a href="https://bridge.setu.co/v2/" target="_blank">The Bridge ↗</a>, if you haven’t already. This is Setu’s single portal for managing all your integrations with us.
 
 If you face any issues with integration, <a href="https://setu.co/support" target="_blank">raise a support ticket ↗</a> and our team will reach out.
 
@@ -17,7 +17,7 @@ If you face any issues with integration, <a href="https://setu.co/support" targe
 
 ##### Step 1 — Create a biller
 
-The primary entity on the BBPS network is called a “biller”. Go to the <a href="https://bridge.setu.co/products-list/payments" target="_blank">list of products</a> offered by Setu, and select one of the product cards under Payments > Collect BBPS.
+The primary entity on the BBPS network is called a “biller”. Go to the <a href="https://bridge.setu.co/v2/products-list/payments" target="_blank">list of products</a> offered by Setu, and select one of the product cards under Payments > Collect BBPS.
 
 You will see multiple Collect BBPS cards, each by a different bank provider. While the underlying bank might differ, the product experience itself remains consistent across providers. Click on one of those cards, and you should see the full profile page with more details about the product. Click on the “Create a biller” button.
 

--- a/content/payments/bbps/quickstart/no-code-integration.mdx
+++ b/content/payments/bbps/quickstart/no-code-integration.mdx
@@ -26,7 +26,7 @@ See a comparision between CSV upload and API integration <a href="/payments/bbps
 
 ## How to integrate
 
-Start by signing up on <a href="https://bridge.setu.co/" target="_blank">The Bridge ↗</a>, if you haven’t already. This is Setu’s single portal for managing all your integrations with us.
+Start by signing up on <a href="https://bridge.setu.co/v2/" target="_blank">The Bridge ↗</a>, if you haven’t already. This is Setu’s single portal for managing all your integrations with us.
 
 <Callout type="tip">
   If you have an existing biller configuration, skip to Step 3.

--- a/content/payments/upi-deeplinks/quickstart.mdx
+++ b/content/payments/upi-deeplinks/quickstart.mdx
@@ -7,7 +7,7 @@ visible_in_sidebar: true
 
 ## UPI Quickstart
 
-As the first step, sign up on <a href="https://bridge.setu.co/" target="_blank">The Bridge</a>, if you haven’t already. This is where you can create product configurations and add configuration details. Read more on this <a href="/dev-tools/bridge/overview" target="_blank">here</a> and watch <a href="https://www.loom.com/share/fed32a838e7f400294f543c9dc8c5779" target="_blank">this quick video</a> on how to create a test merchant configuration.
+As the first step, sign up on <a href="https://bridge.setu.co/v2/" target="_blank">The Bridge</a>, if you haven’t already. This is where you can create product configurations and add configuration details. Read more on this <a href="/dev-tools/bridge/overview" target="_blank">here</a> and watch <a href="https://www.loom.com/share/fed32a838e7f400294f543c9dc8c5779" target="_blank">this quick video</a> on how to create a test merchant configuration.
 
 Also, listed below are some other details you need to get started. If you do face any issues, [raise a support ticket](https://setu.co/support) and our team will reach out.
 


### PR DESCRIPTION
## What changed

- Updated stale Bridge links in MDX content from bridge.setu.co to bridge.setu.co/v2.
- Preserved existing subpaths such as /signup and /products-list/payments.

## Why

Bridge now lives under the /v2 path, so docs links should send readers to the current Bridge experience.

## Verification

- git diff --check
- rg confirms no non-/v2 bridge.setu.co links remain under content/**/*.mdx

## Notes

Content-only change; no app build run.