### PR TITLE
Mark repository as superseded by docs-showcase

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,21 @@
+# This repository is superseded by brokentusk/facade/docs-showcase (GitLab).
+# Issues filed here are not tracked, so blank issues are disabled and readers are
+# redirected. See DEPRECATED.md at the repository root.
+blank_issues_enabled: false
+contact_links:
+  - name: ⚠️ This repository is no longer maintained — report docs issues in docs-showcase
+    url: https://gitlab.com/brokentusk/facade/docs-showcase/-/issues
+    about: >-
+      Setu's developer docs moved to brokentusk/facade/docs-showcase on GitLab on 28 July 2026.
+      Report anything about docs.setu.co there, not here. Issues opened in this repository are
+      not tracked.
+  - name: Read the published documentation
+    url: https://docs.setu.co
+    about: >-
+      docs.setu.co is public and always reflects the current documentation. Start here if you do
+      not have access to the GitLab repository.
+  - name: What moved, and where to make each kind of change
+    url: https://github.com/SetuHQ/docs/blob/main/DEPRECATED.md
+    about: >-
+      Explains what this repository was, what replaced it, what still lives here (the API
+      playground data is still served from this branch), and what to do instead.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Please read before filling this in. -->
+
+> ## ⚠️ This repository is frozen — docs changes here do not reach docs.setu.co
+>
+> Setu's developer docs moved to [`brokentusk/facade/docs-showcase`](https://gitlab.com/brokentusk/facade/docs-showcase)
+> on GitLab on 28 July 2026. That repository holds both the content and the site that renders it.
+>
+> - **Editing a page, adding a product, or changing an API spec shown on docs.setu.co?**
+>   Close this pull request and open a merge request against `docs-showcase` instead
+>   (`main` for production, `development` for staging).
+> - **Changing an API playground mock payload under `api-playground/`?** That is still done
+>   here, on `main` — [api-playground.setu.co](https://api-playground.setu.co) reads this
+>   branch at runtime. Carry on, and say so below.
+>
+> See [`DEPRECATED.md`](https://github.com/SetuHQ/docs/blob/main/DEPRECATED.md) for what moved, what did not, and what to do
+> for each kind of change.
+
+---
+
+**What does this change, and why does it belong in this repository rather than `docs-showcase`?**
+
+<!-- e.g. "API playground mock payload — still served from this repo at runtime."
+     If this is a docs content change, it almost certainly belongs in docs-showcase. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,20 @@
 # CLAUDE.md
 
+> **⚠️ This repository is no longer maintained.** Setu's developer docs moved to
+> `brokentusk/facade/docs-showcase` on GitLab (Next.js + Fumadocs, content and rendering in one
+> repository) on 28 July 2026. docs.setu.co is served from there.
+>
+> **Do not make documentation content changes here** — editing `content/` or `api-references/` in
+> this repository has no effect on docs.setu.co. Content changes belong in `docs-showcase`
+> (`content/docs/`), and the ingestion/embeddings pipelines described below now live there as
+> `rag/ingestion/` and `rag/embeddings/`.
+>
+> The one exception is `api-playground/`, which api-playground.setu.co still fetches from this
+> repository's `main` branch at runtime.
+>
+> Read [`DEPRECATED.md`](./DEPRECATED.md) first. Everything below is accurate as a description of
+> this repository's frozen state, but is no longer how Setu's docs are built or changed.
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Repository Overview

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,0 +1,95 @@
+# This repository is superseded
+
+`SetuHQ/docs` is no longer the source of Setu's developer documentation. It is kept online for
+its git history and because a small part of it is still read at runtime (see
+[What still lives here](#what-still-lives-here)).
+
+**Replacement:** [`brokentusk/facade/docs-showcase`](https://gitlab.com/brokentusk/facade/docs-showcase) (GitLab)
+
+**Cutover date:** 28 July 2026
+
+## What this repository was
+
+The content half of Setu's docs:
+
+- `content/` — documentation pages as MDX, plus `endpoints.json`, `menuItems.json` and `redirects.json`
+- `api-references/` — OpenAPI/Swagger specs, one per product
+- `api-playground/` — mock request payloads and `products.json` for [api-playground.setu.co](https://api-playground.setu.co)
+- `docs-ingestion/` and `docs-embeddings/` — TypeScript pipelines that chunked and embedded the
+  above into Pinecone + S3 for the docs copilot
+
+It had no renderer of its own. The site was built by a separate GitLab repository,
+`brokentusk/facade/docs-mdx`, which read this repository's content. The two together served
+docs.setu.co, and a docs change usually meant a pull request here plus a deploy there.
+
+## What replaced it
+
+`docs-showcase` is a single Next.js + Fumadocs application that holds content *and* rendering in
+one repository. One merge request now changes both a page and the site that serves it.
+
+The RAG pipelines were carried over too: `docs-ingestion/` and `docs-embeddings/` here correspond
+to `rag/ingestion/` and `rag/embeddings/` there, wired into that repository's CI.
+
+`brokentusk/facade/docs-mdx` is dormant alongside this repository — it was the renderer for the
+same superseded setup.
+
+### Environments
+
+| Site | Served from |
+|---|---|
+| [docs.setu.co](https://docs.setu.co) | `docs-showcase` → `main` |
+| [docs-staging.setu.co](https://docs-staging.setu.co) | `docs-showcase` → `development` |
+
+## Content parity
+
+Content was ported page by page rather than copied — it was re-authored for Fumadocs, so no file
+is byte-identical to its counterpart. The baselines at cutover:
+
+| This repository | Ported up to | Landed on |
+|---|---|---|
+| `main` | `e226a98` | `docs-showcase` → `main` |
+| `staging` | `16dcd01` | `docs-showcase` → `development` |
+
+Both were the branch tips on 28 July 2026. `staging` content lands on `development` rather than
+`main` because `staging` carried products `main` did not (Signal IQ, UPI Issuance) that were not
+yet cleared to go live.
+
+The authoritative, maintained record of parity is `docs/UPSTREAM_SYNC.md` in `docs-showcase`.
+Consult it rather than this file if you need to reason about a specific page — it also documents
+the deliberate divergences, including pages that exist only in `docs-showcase`, upstream pages
+that were intentionally *not* carried over, and the MDX component conversions that were applied.
+
+Two categories of upstream page have no direct counterpart by design, and are not gaps:
+
+- Section landing pages (`some-section.mdx` beside a `some-section/` folder) — in Fumadocs these
+  are expressed as a `meta.json` in the folder, or as `some-section/index.mdx`.
+- `api-reference.mdx` pages — these are now generated routes rendered from the OpenAPI spec, not
+  authored pages.
+
+## What still lives here
+
+- **Git history.** Every revision of every page and spec. Nothing was deleted from this
+  repository as part of the migration.
+- **The API playground's data, still in production.** `api-playground.setu.co` fetches
+  `api-playground/json/…`, `api-playground/products.json` and `api-references/…` from
+  `raw.githubusercontent.com/SetuHQ/docs/main/…` at request time. This repository's `main` branch
+  is therefore still a live runtime dependency of that site, and `api-playground/README.md`
+  still describes the current way to change those mock payloads. This is the one reason not to
+  treat `main` as inert.
+- **Open branches and pull requests.** Numerous long-lived branches were never merged. Anything
+  still wanted must be re-applied to `docs-showcase`; it will not arrive there on its own.
+
+## What to do instead
+
+| You want to… | Do this |
+|---|---|
+| Edit a page on docs.setu.co | Open a merge request against `docs-showcase` → `main`, editing `content/docs/…`. Changes here have no effect. |
+| Edit a page that is only on staging | Same, but target `development`. |
+| Add a new product | In `docs-showcase`: add the pages under `content/docs/{category}/{product}/`, a `meta.json` for navigation, and register the product in `product-registry.yaml`. `endpoints.json` and `menuItems.json` here are no longer read. |
+| Change an API spec shown on docs.setu.co | Edit the spec in `docs-showcase` under `api-references/`, and update the mirrored copy in `public/api-specs/`. Both must stay in sync. Editing `api-references/` here does **not** update docs.setu.co. |
+| Change an API playground mock payload | Still done here, on `main`, under `api-playground/` — see `api-playground/README.md`. Also update the spec in `docs-showcase` if the API itself changed. |
+| Change how content is chunked or embedded for the docs copilot | `rag/ingestion/` or `rag/embeddings/` in `docs-showcase`. |
+| Find when or why a page changed before the cutover | Read this repository's git history. Pre-cutover history did not transfer to `docs-showcase`. |
+
+If you cannot access `docs-showcase`, the published docs are public at
+[docs.setu.co](https://docs.setu.co); ask your Setu contact for repository access.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# ⚠️ This repository is no longer maintained
+
+Setu's developer docs now live in a single repository, **[`brokentusk/facade/docs-showcase`](https://gitlab.com/brokentusk/facade/docs-showcase)** on GitLab, which holds both the content and the site that renders it. Since **28 July 2026**, [docs.setu.co](https://docs.setu.co) is served from there, not from here.
+
+**To change a docs page, open a merge request against `brokentusk/facade/docs-showcase`.** Changes merged into this repository will not appear on docs.setu.co.
+
+If you do not have access to that GitLab repository, read the published docs at [docs.setu.co](https://docs.setu.co) or ask your Setu contact.
+
+One part of this repository is still live: [api-playground.setu.co](https://api-playground.setu.co) reads `api-playground/` and `api-references/` from this repository's `main` branch at runtime. See [`DEPRECATED.md`](./DEPRECATED.md) for the full picture — what moved, what did not, and what to do for each kind of change.
+
+---
+
+> **The rest of this README is kept for historical reference.** It describes how docs content was edited when this repository still fed docs.setu.co. Apart from the API playground section, it no longer describes how to change the live documentation.
+
 # Setu Documentation : Content + API references
 
 Monorepo of content and API reference of [Setu docs](https://docs.setu.co)

--- a/content/README.md
+++ b/content/README.md
@@ -1,3 +1,11 @@
+> **⚠️ Historical — this is not how Setu docs content is written any more.**
+> Setu's developer docs moved to [`brokentusk/facade/docs-showcase`](https://gitlab.com/brokentusk/facade/docs-showcase)
+> on GitLab on 28 July 2026, and docs.setu.co is served from there. Pages in this folder are no
+> longer published, and the frontmatter and component conventions below are the old ones — the
+> replacement repository uses Fumadocs, with different frontmatter fields and different
+> components. Write new content there, following its own guides. See
+> [`DEPRECATED.md`](../DEPRECATED.md) at the repository root.
+
 # Detailed guide on how to write content for Setu docs
 
 ## Sample content


### PR DESCRIPTION
## Why

`docs.setu.co` has been served by [`brokentusk/facade/docs-showcase`](https://gitlab.com/brokentusk/facade/docs-showcase) since the cutover on **28 July 2026**. This repository and the `brokentusk/facade/docs-mdx` renderer are both superseded, but nothing in the repository says so. It is public, indexed, and heavily bookmarked, so people (and coding agents) still land here, read the README, and edit `content/` expecting it to publish.

This adds the standard "no longer maintained" signposting. **It adds only — no file is deleted and no workflow is modified.**

## What this changes

| File | Change |
|---|---|
| `README.md` | Deprecation banner above everything else. Existing content kept, marked historical. |
| `DEPRECATED.md` | New. Full explanation: what this repo was, what replaced it, cutover date, parity baselines, what still lives here, and a table of what to do for each common task. |
| `.github/PULL_REQUEST_TEMPLATE.md` | New — none existed. Tells anyone opening a PR that the repo is frozen and where to go. |
| `.github/ISSUE_TEMPLATE/config.yml` | New — no `ISSUE_TEMPLATE/` existed. `blank_issues_enabled: false` plus contact links to docs-showcase issues, docs.setu.co, and `DEPRECATED.md`. |
| `CLAUDE.md` | Notice at top. Worth doing explicitly: this file instructs coding agents to edit `content/` and run the ingestion pipelines, which would now be wrong. |
| `content/README.md` | Notice at top. It is the content-authoring guide and its frontmatter/component conventions are the pre-Fumadocs ones. |

There is no `CONTRIBUTING.md`, `CODEOWNERS`, `SUPPORT.md`, or pre-existing deprecation notice anywhere in the repo, so nothing conflicted.

## One thing that is deliberately *not* deprecated

**`api-playground.setu.co` still reads this repository's `main` branch at runtime.** `brokentusk/facade/api-playground` fetches, per request:

- `raw.githubusercontent.com/SetuHQ/docs/main/api-playground/json/…`
- `raw.githubusercontent.com/SetuHQ/docs/main/api-playground/products.json`
- `raw.githubusercontent.com/SetuHQ/docs/main/api-references/{spec}.json|yaml`

Both the site and those raw URLs are live (verified today). So `api-playground/README.md` was left alone — its instructions are still correct — and the notices carve out this exception explicitly rather than telling people to stop editing here entirely. Worth confirming this is the intended steady state, or repointing the playground.

## Facts I verified rather than assumed

- `main` tip is `e226a98`, `staging` tip is `16dcd01` — the parity baselines in `DEPRECATED.md`.
- `docs.setu.co` is served by docs-showcase: the live homepage `<title>` traces to `src/lib/seo.ts` and `src/app/(docs)/page.tsx` on docs-showcase `main`, and does not exist anywhere in `docs-mdx`.
- `docs-staging.setu.co` and `docs-v2-staging.setu.co` return byte-identical responses (same origin); the old parallel-domain `docs-v2.setu.co` now 404s.
- Content parity: comparing page sets after normalising the `section.mdx` → `section/index.mdx` + `meta.json` shape, every upstream page on `main` has a counterpart in docs-showcase `main`, and every page on `staging` has one in `development`. The only residue is the 7 files `UPSTREAM_SYNC.md` marks as deliberate `main` deletions, the Signal IQ `apis/*` pages that became Scalar spec routes, and `sample-category/sample-product/sample-page`.
- `docs-ingestion/` and `docs-embeddings/` correspond to `rag/ingestion/` and `rag/embeddings/` in docs-showcase.
- `docs-mdx`'s last commit was 2026-03-31 — dormant.

## Things I was unsure about — please check

1. **`docs/UPSTREAM_SYNC.md` in docs-showcase only exists on the unmerged `sync/docs-main` branch**, not on `main` or `development`. `DEPRECATED.md` points at it as the authoritative parity record, so that link is a promise that only holds once the branch merges.
2. **That file's `staging` row is still blank** (`ported up to: —`), and it says `main` here maps to `docs-v2.setu.co`, which now 404s. I verified the staging content really is ported to `development` and did not repeat either stale claim, but the file should be refreshed post-cutover.
3. **Staging content parity is real but lands on `development`, not `main`** — Signal IQ and UPI Issuance are not live on docs.setu.co. `DEPRECATED.md` says so; flagging in case that is not the intent now that cutover is done.

## Follow-ups that need a repo owner (not done here, deliberately)

- **Archiving.** Recommended once the API playground no longer reads this branch — archiving makes the repo read-only, which would freeze those runtime-fetched files but also block any playground mock update. Raw URLs keep working on archived public repos, so archiving does not break the playground's reads, only future edits. Owner's call; not touched.
- **`.github/workflows/docs-ingestion-ci.yml`** — untouched as agreed. It still runs on every PR to `main`/`staging`.
- **`.github/workflows/checklist.yml`** — worth a look. It auto-comments a "Checklist to merge a PR" on every PR opened against `main`/`staging`, walking people through adding MDX pages, updating `menuItems.json`, and using the Docter preview extension. All of that is now wrong, and the bot's comment will appear directly below the new PR template that says the opposite. I did not modify it, since disabling a workflow felt like an owner decision adjacent to the ingestion-CI one.
- **Repo description** still reads "Setu Documentation : Content + API References"; prefixing `[SUPERSEDED]` would show the status in search results and org listings, where READMEs are not visible.
- **Open branches.** Many unmerged branches exist; anything still wanted has to be re-applied to docs-showcase by hand.
- **`vscode-docter-preview`** (`SetuHQ/vscode-docter-preview`) is referenced from the README and the checklist bot and is presumably also superseded — out of scope here.
